### PR TITLE
@starsirius: Add phpgotenv in order to load .env, add wp-cli.yml to execute dotenv…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ wp-content/plugins/hello.php
 /sitemap.xml.gz
 
 .env
+vendor/

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "vlucas/phpdotenv": "^2.4"
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,68 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "913950ad60dd11bbcdf3b8f3c8b0c052",
+    "packages": [
+        {
+            "name": "vlucas/phpdotenv",
+            "version": "v2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vlucas/phpdotenv.git",
+                "reference": "3cc116adbe4b11be5ec557bf1d24dc5e3a21d18c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/3cc116adbe4b11be5ec557bf1d24dc5e3a21d18c",
+                "reference": "3cc116adbe4b11be5ec557bf1d24dc5e3a21d18c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8 || ^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dotenv\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause-Attribution"
+            ],
+            "authors": [
+                {
+                    "name": "Vance Lucas",
+                    "email": "vance@vancelucas.com",
+                    "homepage": "http://www.vancelucas.com"
+                }
+            ],
+            "description": "Loads environment variables from `.env` to `getenv()`, `$_ENV` and `$_SERVER` automagically.",
+            "keywords": [
+                "dotenv",
+                "env",
+                "environment"
+            ],
+            "time": "2016-09-01T10:05:43+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}

--- a/dotenv_loader.php
+++ b/dotenv_loader.php
@@ -1,0 +1,5 @@
+<?php
+require __DIR__ . '/vendor/autoload.php';
+ 
+$dotenv = new Dotenv\Dotenv(__DIR__);
+$dotenv->load();

--- a/wp-cli.yml
+++ b/wp-cli.yml
@@ -1,0 +1,3 @@
+#use phpdotenv(https://packagist.org/packages/vlucas/phpdotenv) to load environment variables from .env
+require:
+  - dotenv_loader.php


### PR DESCRIPTION
Add composer files.
Install [phpdotent](https://packagist.org/packages/vlucas/phpdotenv) with composer.
Add dotenv_loader.php to load content of .env file into environment variables.
Setup wp-cli.yam to execute dotenv_loader.php every time we run wp-cli.