### PR TITLE
Add Stripe

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,14 +8,15 @@
   "require": {
     "php": "~7.0.0",
     "wp-cli/wp-cli": "~0.22",
+    "wpackagist-plugin/insert-html-snippet": "~1.2.2",
+    "wpackagist-plugin/perfect-woocommerce-brands": "~1.6.0",
     "wpackagist-plugin/sendgrid-email-delivery-simplified": "~1.11.4",
     "wpackagist-plugin/woocommerce": "~3.2.1",
-    "wpackagist-theme/storefront": "~2.2.5",
-    "wpackagist-plugin/insert-html-snippet": "~1.2.2",
-    "wpackagist-plugin/perfect-woocommerce-brands": "~1.6.0"
+    "wpackagist-plugin/woocommerce-gateway-stripe": "~4.0.3",
+    "wpackagist-theme/storefront": "~2.2.5"
   },
   "scripts": {
-    "post-install-cmd": "wp plugin activate sendgrid-email-delivery-simplified woocommerce insert-html-snippet perfect-woocommerce-brands; wp theme activate storefront-child",
+    "post-install-cmd": "wp plugin activate sendgrid-email-delivery-simplified woocommerce insert-html-snippet perfect-woocommerce-brands woocommerce-gateway-stripe; wp theme activate storefront-child",
     "test": "phpunit -v tests"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -11,14 +11,14 @@
     "wpackagist-plugin/sendgrid-email-delivery-simplified": "~1.11.4",
     "wpackagist-plugin/woocommerce": "~3.2.1",
     "wpackagist-theme/storefront": "~2.2.5",
-    "wpackagist-plugin/insert-html-snippet": "^1.2",
-    "wpackagist-plugin/perfect-woocommerce-brands": "^1.5"
+    "wpackagist-plugin/insert-html-snippet": "~1.2.2",
+    "wpackagist-plugin/perfect-woocommerce-brands": "~1.6.0"
   },
   "scripts": {
     "post-install-cmd": "wp plugin activate sendgrid-email-delivery-simplified woocommerce insert-html-snippet perfect-woocommerce-brands; wp theme activate storefront-child",
     "test": "phpunit -v tests"
   },
   "require-dev": {
-    "phpunit/phpunit": "^6.5"
+    "phpunit/phpunit": "~6.5.0"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "280a4cb79003e3af1e95999f63f15961",
+    "content-hash": "044468de4e77f15328fc60086e525a55",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -776,16 +776,16 @@
         },
         {
             "name": "seld/jsonlint",
-            "version": "1.7.0",
+            "version": "1.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/jsonlint.git",
-                "reference": "9b355654ea99460397b89c132b5c1087b6bf4473"
+                "reference": "d15f59a67ff805a44c50ea0516d2341740f81a38"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/9b355654ea99460397b89c132b5c1087b6bf4473",
-                "reference": "9b355654ea99460397b89c132b5c1087b6bf4473",
+                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/d15f59a67ff805a44c50ea0516d2341740f81a38",
+                "reference": "d15f59a67ff805a44c50ea0516d2341740f81a38",
                 "shasum": ""
             },
             "require": {
@@ -821,7 +821,7 @@
                 "parser",
                 "validator"
             ],
-            "time": "2018-01-03T12:13:57+00:00"
+            "time": "2018-01-24T12:46:19+00:00"
         },
         {
             "name": "seld/phar-utils",
@@ -1602,16 +1602,16 @@
         },
         {
             "name": "wpackagist-plugin/insert-html-snippet",
-            "version": "1.2.2",
+            "version": "1.2.3",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/insert-html-snippet/",
-                "reference": "tags/1.2.2"
+                "reference": "tags/1.2.3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/insert-html-snippet.1.2.2.zip",
-                "reference": "tags/1.2.2",
+                "url": "https://downloads.wordpress.org/plugin/insert-html-snippet.1.2.3.zip",
+                "reference": null,
                 "shasum": null
             },
             "require": {
@@ -1671,7 +1671,7 @@
             "dist": {
                 "type": "zip",
                 "url": "https://downloads.wordpress.org/plugin/woocommerce.3.2.6.zip",
-                "reference": null,
+                "reference": "tags/3.2.6",
                 "shasum": null
             },
             "require": {
@@ -1682,16 +1682,16 @@
         },
         {
             "name": "wpackagist-theme/storefront",
-            "version": "2.2.5",
+            "version": "2.2.7",
             "source": {
                 "type": "svn",
                 "url": "https://themes.svn.wordpress.org/storefront/",
-                "reference": "2.2.5"
+                "reference": "2.2.7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/theme/storefront.2.2.5.zip",
-                "reference": "2.2.5",
+                "url": "https://downloads.wordpress.org/theme/storefront.2.2.7.zip",
+                "reference": null,
                 "shasum": null
             },
             "require": {
@@ -1959,16 +1959,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "4.2.0",
+            "version": "4.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "66465776cfc249844bde6d117abff1d22e06c2da"
+                "reference": "94fd0001232e47129dd3504189fa1c7225010d08"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/66465776cfc249844bde6d117abff1d22e06c2da",
-                "reference": "66465776cfc249844bde6d117abff1d22e06c2da",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/94fd0001232e47129dd3504189fa1c7225010d08",
+                "reference": "94fd0001232e47129dd3504189fa1c7225010d08",
                 "shasum": ""
             },
             "require": {
@@ -2006,7 +2006,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-11-27T17:38:31+00:00"
+            "time": "2017-11-30T07:14:17+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "044468de4e77f15328fc60086e525a55",
+    "content-hash": "9db61f8c379a68e95b00a6f48593aca7",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -1611,7 +1611,7 @@
             "dist": {
                 "type": "zip",
                 "url": "https://downloads.wordpress.org/plugin/insert-html-snippet.1.2.3.zip",
-                "reference": null,
+                "reference": "tags/1.2.3",
                 "shasum": null
             },
             "require": {
@@ -1681,6 +1681,26 @@
             "homepage": "https://wordpress.org/plugins/woocommerce/"
         },
         {
+            "name": "wpackagist-plugin/woocommerce-gateway-stripe",
+            "version": "4.0.3",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/woocommerce-gateway-stripe/",
+                "reference": "tags/4.0.3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/woocommerce-gateway-stripe.4.0.3.zip",
+                "reference": null,
+                "shasum": null
+            },
+            "require": {
+                "composer/installers": "~1.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/woocommerce-gateway-stripe/"
+        },
+        {
             "name": "wpackagist-theme/storefront",
             "version": "2.2.7",
             "source": {
@@ -1691,7 +1711,7 @@
             "dist": {
                 "type": "zip",
                 "url": "https://downloads.wordpress.org/theme/storefront.2.2.7.zip",
-                "reference": null,
+                "reference": "2.2.7",
                 "shasum": null
             },
             "require": {


### PR DESCRIPTION
This adds the official [woocommerce-gateway-stripe](https://wordpress.org/plugins/woocommerce-gateway-stripe/) package.

After activating the Stripe plugin, I followed the steps below to test the entire checkout flow on my local:
1. Copy the "Cart" and "Checkout" pages from staging to my local Wordpress.
1. In my local Wordpress WooCommerce settings -> checkout, select the Cart page and Checkout page to use the above we just copied over.
1. Go to WooCommerce settings -> checkout -> stripe, enable Stripe and test mode, and fill in test publishable key and test secret key (keys in Stripe dashboard)
1. In order to receive test webhooks from Stripe with localhost, I use [ngrok](https://ngrok.com/) to set up tunnels to localhost.
   1. Install ngrok with `npm -g ngrok`.
   1. Run it with `ngrok http 7070`.
   1. Copy the forwarding address (e.g. `http://3ec8bbdb.ngrok.io`). Replace the localhost in the Webhook Endpoints prompted in WooCommerce Stripe settings with the forwarding address, and use that to set up a test webhook endpoint in Stripe dashboard. It should look something like `http://72305cf3.ngrok.io/?wc-api=wc_stripe`.