### PR TITLE
Kill php-fpm processes when exiting from php-fpm script

### DIFF
--- a/script/start_local_php-fpm.sh
+++ b/script/start_local_php-fpm.sh
@@ -6,4 +6,10 @@ set -e
 PHP_FPM_CONF_PATH="config/php-fpm/php-fpm.conf"
 
 php "$PHP_FPM_CONF_PATH.php" > $PHP_FPM_CONF_PATH
-php-fpm --nodaemonize -y "$PWD/$PHP_FPM_CONF_PATH"
+
+trap 'kill -INT $pid; exit' INT;
+(
+  php-fpm --nodaemonize -y "$PWD/$PHP_FPM_CONF_PATH"
+) & pid=$!
+
+while true; do read; done


### PR DESCRIPTION
Fixes https://github.com/mypickee/pickee-wp/issues/27

When running the current php-fpm processes via the script
(script/start_local_php-fpm.sh), Ctrl+C does not kill the php-fpm
processes, even the script process itself. Perhaps it's related to
bash's implementation of WCE (wait and cooperative exit).

Wrapping the php-fpm command in a subshell, trapping the INT signal, and
sending it to the subshell process manually solves it. We may explore
more sophisticated solution like Heroku's buildpack, but this seems to
be a quick fix.

https://unix.stackexchange.com/questions/230421/unable-to-stop-a-bash-script-with-ctrlc
https://github.com/heroku/heroku-buildpack-php/blob/06a81e71d94115668de3f202547fd9d517dc76ca/bin/heroku-php-nginx