### PR TITLE
Style view order page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@
 
 config/nginx/pickee-wp
 config/php-fpm/php-fpm.conf
+
+.sass-cache

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,3 @@
 fpm: ./script/start_local_php-fpm.sh
 web: ./script/start_local_nginx.sh
+compass: compass watch wp-content/themes/storefront-child/sass

--- a/wp-content/themes/storefront-child/sass/sass/override/_account.scss
+++ b/wp-content/themes/storefront-child/sass/sass/override/_account.scss
@@ -116,3 +116,26 @@ table.woocommerce-MyAccount-paymentMethods {
     text-align: right;
   }
 }
+
+.view-order__header {
+  @include breakpoint($screen-sm) {
+    & {
+      display: flex;
+      align-items: center;
+    }
+    .view-order__header__id {
+      flex: 0 0 150px;
+    }
+    .view-order__header__details {
+      flex: 1 0 0;
+      text-align: right;
+    }
+  }
+}
+.view-order__header__id {
+  font-size: 20px;
+  font-weight: bold;
+}
+.view-order__header__details {
+  font-size: 14px;
+}

--- a/wp-content/themes/storefront-child/sass/sass/override/_account.scss
+++ b/wp-content/themes/storefront-child/sass/sass/override/_account.scss
@@ -118,6 +118,7 @@ table.woocommerce-MyAccount-paymentMethods {
 }
 
 .view-order__header {
+  margin-bottom: 15px;
   @include breakpoint($screen-sm) {
     & {
       display: flex;

--- a/wp-content/themes/storefront-child/sass/sass/override/_account.scss
+++ b/wp-content/themes/storefront-child/sass/sass/override/_account.scss
@@ -140,3 +140,40 @@ table.woocommerce-MyAccount-paymentMethods {
 .view-order__header__details {
   font-size: 14px;
 }
+
+// order details table
+.order_details {
+  background-color: transparent;
+  th, td {
+    padding: 1em;
+    &:first-child {
+      padding-left: 0;
+    }
+    &:last-child {
+      padding-right: 0;
+      text-align: right;
+    }
+  }
+  tbody {
+    td {
+      border-bottom: solid 1px $gray-light;
+    }
+    tr:last-child {
+      td {
+        border-bottom-color: $gray;
+      }
+    }
+  }
+  tfoot {
+    td {
+      padding: 0.8em;
+    }
+    tr:last-child {
+      td:nth-last-child(-n+2) {
+        border-top: solid 2px $black;
+        font-weight: bold;
+        font-size: 20px;
+      }
+    }
+  }
+}

--- a/wp-content/themes/storefront-child/sass/sass/override/_account.scss
+++ b/wp-content/themes/storefront-child/sass/sass/override/_account.scss
@@ -177,3 +177,12 @@ table.woocommerce-MyAccount-paymentMethods {
     }
   }
 }
+
+.order-details-billing-address,
+.order-details-shipping-address {
+  border-top: 4px solid $black;
+  border-bottom: 2px solid $gray-light;
+  address {
+    font-style: normal;
+  }
+}

--- a/wp-content/themes/storefront-child/style.css
+++ b/wp-content/themes/storefront-child/style.css
@@ -1835,6 +1835,34 @@ table.woocommerce-MyAccount-paymentMethods td.payment-method-actions {
   text-align: right;
 }
 
+@media (min-width: 768px) {
+  /* line 122, sass/sass/override/_account.scss */
+  .view-order__header {
+    display: flex;
+    align-items: center;
+  }
+  /* line 126, sass/sass/override/_account.scss */
+  .view-order__header .view-order__header__id {
+    flex: 0 0 150px;
+  }
+  /* line 129, sass/sass/override/_account.scss */
+  .view-order__header .view-order__header__details {
+    flex: 1 0 0;
+    text-align: right;
+  }
+}
+
+/* line 135, sass/sass/override/_account.scss */
+.view-order__header__id {
+  font-size: 20px;
+  font-weight: bold;
+}
+
+/* line 139, sass/sass/override/_account.scss */
+.view-order__header__details {
+  font-size: 14px;
+}
+
 /* line 1, sass/sass/override/_other.scss */
 .woocommerce-breadcrumb {
   margin-bottom: 1em;

--- a/wp-content/themes/storefront-child/style.css
+++ b/wp-content/themes/storefront-child/style.css
@@ -1903,6 +1903,18 @@ table.woocommerce-MyAccount-paymentMethods td.payment-method-actions {
   font-size: 20px;
 }
 
+/* line 181, sass/sass/override/_account.scss */
+.order-details-billing-address,
+.order-details-shipping-address {
+  border-top: 4px solid #222222;
+  border-bottom: 2px solid #cccccc;
+}
+/* line 185, sass/sass/override/_account.scss */
+.order-details-billing-address address,
+.order-details-shipping-address address {
+  font-style: normal;
+}
+
 /* line 1, sass/sass/override/_other.scss */
 .woocommerce-breadcrumb {
   margin-bottom: 1em;

--- a/wp-content/themes/storefront-child/style.css
+++ b/wp-content/themes/storefront-child/style.css
@@ -1835,30 +1835,34 @@ table.woocommerce-MyAccount-paymentMethods td.payment-method-actions {
   text-align: right;
 }
 
+/* line 120, sass/sass/override/_account.scss */
+.view-order__header {
+  margin-bottom: 15px;
+}
 @media (min-width: 768px) {
-  /* line 122, sass/sass/override/_account.scss */
+  /* line 123, sass/sass/override/_account.scss */
   .view-order__header {
     display: flex;
     align-items: center;
   }
-  /* line 126, sass/sass/override/_account.scss */
+  /* line 127, sass/sass/override/_account.scss */
   .view-order__header .view-order__header__id {
     flex: 0 0 150px;
   }
-  /* line 129, sass/sass/override/_account.scss */
+  /* line 130, sass/sass/override/_account.scss */
   .view-order__header .view-order__header__details {
     flex: 1 0 0;
     text-align: right;
   }
 }
 
-/* line 135, sass/sass/override/_account.scss */
+/* line 136, sass/sass/override/_account.scss */
 .view-order__header__id {
   font-size: 20px;
   font-weight: bold;
 }
 
-/* line 139, sass/sass/override/_account.scss */
+/* line 140, sass/sass/override/_account.scss */
 .view-order__header__details {
   font-size: 14px;
 }

--- a/wp-content/themes/storefront-child/style.css
+++ b/wp-content/themes/storefront-child/style.css
@@ -1867,6 +1867,42 @@ table.woocommerce-MyAccount-paymentMethods td.payment-method-actions {
   font-size: 14px;
 }
 
+/* line 145, sass/sass/override/_account.scss */
+.order_details {
+  background-color: transparent;
+}
+/* line 147, sass/sass/override/_account.scss */
+.order_details th, .order_details td {
+  padding: 1em;
+}
+/* line 149, sass/sass/override/_account.scss */
+.order_details th:first-child, .order_details td:first-child {
+  padding-left: 0;
+}
+/* line 152, sass/sass/override/_account.scss */
+.order_details th:last-child, .order_details td:last-child {
+  padding-right: 0;
+  text-align: right;
+}
+/* line 158, sass/sass/override/_account.scss */
+.order_details tbody td {
+  border-bottom: solid 1px #cccccc;
+}
+/* line 162, sass/sass/override/_account.scss */
+.order_details tbody tr:last-child td {
+  border-bottom-color: #999999;
+}
+/* line 168, sass/sass/override/_account.scss */
+.order_details tfoot td {
+  padding: 0.8em;
+}
+/* line 172, sass/sass/override/_account.scss */
+.order_details tfoot tr:last-child td:nth-last-child(-n+2) {
+  border-top: solid 2px #222222;
+  font-weight: bold;
+  font-size: 20px;
+}
+
 /* line 1, sass/sass/override/_other.scss */
 .woocommerce-breadcrumb {
   margin-bottom: 1em;

--- a/wp-content/themes/storefront-child/woocommerce/myaccount/view-order.php
+++ b/wp-content/themes/storefront-child/woocommerce/myaccount/view-order.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * View Order
+ *
+ * Shows the details of a particular order on the account page.
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/myaccount/view-order.php.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see     https://docs.woocommerce.com/document/template-structure/
+ * @author  WooThemes
+ * @package WooCommerce/Templates
+ * @version 3.0.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+  exit;
+}
+
+?>
+<div class="view-order__header">
+<?php
+  /* translators: 1: order number 2: order date 3: order status */
+  printf(
+    __( '<div class="view-order__header__id">Order #%1$s</div><div class="view-order__header__details">was placed on %2$s and is currently %3$s.</div>', 'woocommerce' ),
+    $order->get_order_number(),
+    wc_format_datetime( $order->get_date_created() ),
+    wc_get_order_status_name( $order->get_status() )
+  );
+?>
+</div>
+
+<?php if ( $notes = $order->get_customer_order_notes() ) : ?>
+  <h2><?php _e( 'Order updates', 'woocommerce' ); ?></h2>
+  <ol class="woocommerce-OrderUpdates commentlist notes">
+    <?php foreach ( $notes as $note ) : ?>
+    <li class="woocommerce-OrderUpdate comment note">
+      <div class="woocommerce-OrderUpdate-inner comment_container">
+        <div class="woocommerce-OrderUpdate-text comment-text">
+          <p class="woocommerce-OrderUpdate-meta meta"><?php echo date_i18n( __( 'l jS \o\f F Y, h:ia', 'woocommerce' ), strtotime( $note->comment_date ) ); ?></p>
+          <div class="woocommerce-OrderUpdate-description description">
+            <?php echo wpautop( wptexturize( $note->comment_content ) ); ?>
+          </div>
+            <div class="clear"></div>
+          </div>
+        <div class="clear"></div>
+      </div>
+    </li>
+    <?php endforeach; ?>
+  </ol>
+<?php endif; ?>
+
+<?php do_action( 'woocommerce_view_order', $order_id ); ?>

--- a/wp-content/themes/storefront-child/woocommerce/order/order-details-customer.php
+++ b/wp-content/themes/storefront-child/woocommerce/order/order-details-customer.php
@@ -19,19 +19,15 @@
 if ( ! defined( 'ABSPATH' ) ) {
   exit;
 }
-$show_shipping = ! wc_ship_to_billing_address_only() && $order->needs_shipping_address();
 ?>
 <section class="woocommerce-customer-details">
-
-  <?php if ( $show_shipping ) : ?>
-
   <section class="woocommerce-columns woocommerce-columns--2 woocommerce-columns--addresses col2-set addresses">
-    <div class="woocommerce-column woocommerce-column--1 woocommerce-column--billing-address col-1">
-
-      <?php endif; ?>
-
-      <h2 class="woocommerce-column__title"><?php _e( 'Billing address', 'woocommerce' ); ?></h2>
-
+    <div class="woocommerce-column woocommerce-column--1 woocommerce-column--billing-address col-1 order-details-billing-address">
+      <header class="woocommerce-Address-title title">
+        <h2 class="woocommerce-column__title">
+          <?php _e( 'Billing address', 'woocommerce' ); ?>
+        </h2>
+      </header>
       <address>
         <?php echo wp_kses_post( $order->get_formatted_billing_address( __( 'N/A', 'woocommerce' ) ) ); ?>
 
@@ -43,20 +39,17 @@ $show_shipping = ! wc_ship_to_billing_address_only() && $order->needs_shipping_a
         <p class="woocommerce-customer-details--email"><?php echo esc_html( $order->get_billing_email() ); ?></p>
         <?php endif; ?>
       </address>
+    </div>
 
-      <?php if ( $show_shipping ) : ?>
-
-    </div><!-- /.col-1 -->
-
-    <div class="woocommerce-column woocommerce-column--2 woocommerce-column--shipping-address col-2">
-      <h2 class="woocommerce-column__title"><?php _e( 'Shipping address', 'woocommerce' ); ?></h2>
-        <address>
+    <div class="woocommerce-column woocommerce-column--2 woocommerce-column--shipping-address col-2 order-details-shipping-address">
+      <header class="woocommerce-Address-title title">
+        <h2 class="woocommerce-column__title">
+          <?php _e( 'Shipping address', 'woocommerce' ); ?>
+        </h2>
+      </header>
+      <address>
         <?php echo wp_kses_post( $order->get_formatted_shipping_address( __( 'N/A', 'woocommerce' ) ) ); ?>
-        </address>
-      </div><!-- /.col-2 -->
-
-  </section><!-- /.col2-set -->
-
-  <?php endif; ?>
-
+      </address>
+    </div>
+  </section>
 </section>

--- a/wp-content/themes/storefront-child/woocommerce/order/order-details-customer.php
+++ b/wp-content/themes/storefront-child/woocommerce/order/order-details-customer.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Order Customer Details
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/order/order-details-customer.php.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see 	https://docs.woocommerce.com/document/template-structure/
+ * @author  WooThemes
+ * @package WooCommerce/Templates
+ * @version 3.3.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+  exit;
+}
+$show_shipping = ! wc_ship_to_billing_address_only() && $order->needs_shipping_address();
+?>
+<section class="woocommerce-customer-details">
+
+  <?php if ( $show_shipping ) : ?>
+
+  <section class="woocommerce-columns woocommerce-columns--2 woocommerce-columns--addresses col2-set addresses">
+    <div class="woocommerce-column woocommerce-column--1 woocommerce-column--billing-address col-1">
+
+      <?php endif; ?>
+
+      <h2 class="woocommerce-column__title"><?php _e( 'Billing address', 'woocommerce' ); ?></h2>
+
+      <address>
+        <?php echo wp_kses_post( $order->get_formatted_billing_address( __( 'N/A', 'woocommerce' ) ) ); ?>
+
+        <?php if ( $order->get_billing_phone() ) : ?>
+        <p class="woocommerce-customer-details--phone"><?php echo esc_html( $order->get_billing_phone() ); ?></p>
+        <?php endif; ?>
+
+        <?php if ( $order->get_billing_email() ) : ?>
+        <p class="woocommerce-customer-details--email"><?php echo esc_html( $order->get_billing_email() ); ?></p>
+        <?php endif; ?>
+      </address>
+
+      <?php if ( $show_shipping ) : ?>
+
+    </div><!-- /.col-1 -->
+
+    <div class="woocommerce-column woocommerce-column--2 woocommerce-column--shipping-address col-2">
+      <h2 class="woocommerce-column__title"><?php _e( 'Shipping address', 'woocommerce' ); ?></h2>
+        <address>
+        <?php echo wp_kses_post( $order->get_formatted_shipping_address( __( 'N/A', 'woocommerce' ) ) ); ?>
+        </address>
+      </div><!-- /.col-2 -->
+
+  </section><!-- /.col2-set -->
+
+  <?php endif; ?>
+
+</section>

--- a/wp-content/themes/storefront-child/woocommerce/order/order-details-item.php
+++ b/wp-content/themes/storefront-child/woocommerce/order/order-details-item.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Order Item Details
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/order/order-details-item.php.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see 	https://docs.woocommerce.com/document/template-structure/
+ * @author  WooThemes
+ * @package WooCommerce/Templates
+ * @version 3.0.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+  exit;
+}
+
+if ( ! apply_filters( 'woocommerce_order_item_visible', true, $item ) ) {
+  return;
+}
+?>
+<tr class="<?php echo esc_attr( apply_filters( 'woocommerce_order_item_class', 'woocommerce-table__line-item order_item', $item, $order ) ); ?>">
+
+  <td class="woocommerce-table__product-name product-name">
+<?php
+$is_visible        = $product && $product->is_visible();
+$product_permalink = apply_filters( 'woocommerce_order_item_permalink', $is_visible ? $product->get_permalink( $item ) : '', $item, $order );
+
+echo apply_filters( 'woocommerce_order_item_name', $product_permalink ? sprintf( '<a href="%s">%s</a>', $product_permalink, $item->get_name() ) : $item->get_name(), $item, $is_visible );
+echo apply_filters( 'woocommerce_order_item_quantity_html', ' <strong class="product-quantity">' . sprintf( '&times; %s', $item->get_quantity() ) . '</strong>', $item );
+
+do_action( 'woocommerce_order_item_meta_start', $item_id, $item, $order, false );
+
+wc_display_item_meta( $item );
+
+do_action( 'woocommerce_order_item_meta_end', $item_id, $item, $order, false );
+?>
+  </td>
+
+  <td class="woocommerce-table__product-total product-total">
+    <?php echo $order->get_formatted_line_subtotal( $item ); ?>
+  </td>
+
+</tr>
+
+<?php if ( $show_purchase_note && $purchase_note ) : ?>
+
+<tr class="woocommerce-table__product-purchase-note product-purchase-note">
+  <td colspan="2"><?php echo wpautop( do_shortcode( wp_kses_post( $purchase_note ) ) ); ?></td>
+</tr>
+
+<?php endif; ?>

--- a/wp-content/themes/storefront-child/woocommerce/order/order-details-item.php
+++ b/wp-content/themes/storefront-child/woocommerce/order/order-details-item.php
@@ -27,22 +27,23 @@ if ( ! apply_filters( 'woocommerce_order_item_visible', true, $item ) ) {
 <tr class="<?php echo esc_attr( apply_filters( 'woocommerce_order_item_class', 'woocommerce-table__line-item order_item', $item, $order ) ); ?>">
 
   <td class="woocommerce-table__product-name product-name">
-<?php
-$is_visible        = $product && $product->is_visible();
-$product_permalink = apply_filters( 'woocommerce_order_item_permalink', $is_visible ? $product->get_permalink( $item ) : '', $item, $order );
-
-echo apply_filters( 'woocommerce_order_item_name', $product_permalink ? sprintf( '<a href="%s">%s</a>', $product_permalink, $item->get_name() ) : $item->get_name(), $item, $is_visible );
-echo apply_filters( 'woocommerce_order_item_quantity_html', ' <strong class="product-quantity">' . sprintf( '&times; %s', $item->get_quantity() ) . '</strong>', $item );
-
-do_action( 'woocommerce_order_item_meta_start', $item_id, $item, $order, false );
-
-wc_display_item_meta( $item );
-
-do_action( 'woocommerce_order_item_meta_end', $item_id, $item, $order, false );
-?>
+    <?php
+      echo $item->get_name();
+      do_action( 'woocommerce_order_item_meta_start', $item_id, $item, $order, false );
+      wc_display_item_meta( $item );
+      do_action( 'woocommerce_order_item_meta_end', $item_id, $item, $order, false );
+    ?>
   </td>
 
-  <td class="woocommerce-table__product-total product-total">
+  <td class="woocommerce-table__product-total product-unit-price">
+    <?php echo wc_price($item->get_product()->get_price()) ?>
+  </td>
+
+  <td class="woocommerce-table__product-total product-quantity">
+    <?php echo $item->get_quantity(); ?>
+  </td>
+
+  <td class="woocommerce-table__product-total product-total-price">
     <?php echo $order->get_formatted_line_subtotal( $item ); ?>
   </td>
 

--- a/wp-content/themes/storefront-child/woocommerce/order/order-details.php
+++ b/wp-content/themes/storefront-child/woocommerce/order/order-details.php
@@ -41,8 +41,10 @@ if ( $show_downloads ) {
   <table class="woocommerce-table woocommerce-table--order-details shop_table order_details">
     <thead>
       <tr>
-        <th class="woocommerce-table__product-name product-name"><?php _e( 'Product', 'woocommerce' ); ?></th>
-        <th class="woocommerce-table__product-table product-total"><?php _e( 'Total', 'woocommerce' ); ?></th>
+        <th class="woocommerce-table__product-table product-name"><?php _e( 'Item', 'woocommerce' ); ?></th>
+        <th class="woocommerce-table__product-table product-unit-price"><?php _e( 'Item Price', 'woocommerce' ); ?></th>
+        <th class="woocommerce-table__product-table product-quantity"><?php _e( 'Qty', 'woocommerce' ); ?></th>
+        <th class="woocommerce-table__product-table product-total-price"><?php _e( 'Total Price', 'woocommerce' ); ?></th>
       </tr>
     </thead>
 
@@ -72,7 +74,9 @@ if ( $show_downloads ) {
         foreach ( $order->get_order_item_totals() as $key => $total ) {
           ?>
           <tr>
-            <th scope="row"><?php echo $total['label']; ?></th>
+            <td></td>
+            <td></td>
+            <td scope="row"><?php echo $total['label']; ?></td>
             <td><?php echo $total['value']; ?></td>
           </tr>
           <?php

--- a/wp-content/themes/storefront-child/woocommerce/order/order-details.php
+++ b/wp-content/themes/storefront-child/woocommerce/order/order-details.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Order details
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/order/order-details.php.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see     https://docs.woocommerce.com/document/template-structure/
+ * @author  WooThemes
+ * @package WooCommerce/Templates
+ * @version 3.3.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+  exit;
+}
+
+if ( ! $order = wc_get_order( $order_id ) ) {
+  return;
+}
+
+$order_items           = $order->get_items( apply_filters( 'woocommerce_purchase_order_item_types', 'line_item' ) );
+$show_purchase_note    = $order->has_status( apply_filters( 'woocommerce_purchase_note_order_statuses', array( 'completed', 'processing' ) ) );
+$show_customer_details = is_user_logged_in() && $order->get_user_id() === get_current_user_id();
+$downloads             = $order->get_downloadable_items();
+$show_downloads        = $order->has_downloadable_item() && $order->is_download_permitted();
+
+if ( $show_downloads ) {
+  wc_get_template( 'order/order-downloads.php', array( 'downloads' => $downloads, 'show_title' => true ) );
+}
+
+?>
+<section class="woocommerce-order-details">
+  <?php do_action( 'woocommerce_order_details_before_order_table', $order ); ?>
+
+  <h2 class="woocommerce-order-details__title"><?php _e( 'Order details', 'woocommerce' ); ?></h2>
+  <table class="woocommerce-table woocommerce-table--order-details shop_table order_details">
+    <thead>
+      <tr>
+        <th class="woocommerce-table__product-name product-name"><?php _e( 'Product', 'woocommerce' ); ?></th>
+        <th class="woocommerce-table__product-table product-total"><?php _e( 'Total', 'woocommerce' ); ?></th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <?php
+      do_action( 'woocommerce_order_details_before_order_table_items', $order );
+
+      foreach ( $order_items as $item_id => $item ) {
+        $product = $item->get_product();
+
+        wc_get_template( 'order/order-details-item.php', array(
+          'order'               => $order,
+          'item_id'             => $item_id,
+          'item'                => $item,
+          'show_purchase_note'  => $show_purchase_note,
+          'purchase_note'       => $product ? $product->get_purchase_note() : '',
+          'product'             => $product,
+        ) );
+      }
+
+      do_action( 'woocommerce_order_details_after_order_table_items', $order );
+      ?>
+    </tbody>
+
+    <tfoot>
+      <?php
+        foreach ( $order->get_order_item_totals() as $key => $total ) {
+          ?>
+          <tr>
+            <th scope="row"><?php echo $total['label']; ?></th>
+            <td><?php echo $total['value']; ?></td>
+          </tr>
+          <?php
+        }
+      ?>
+      <?php if ( $order->get_customer_note() ) : ?>
+        <tr>
+          <th><?php _e( 'Note:', 'woocommerce' ); ?></th>
+          <td><?php echo wptexturize( $order->get_customer_note() ); ?></td>
+        </tr>
+      <?php endif; ?>
+    </tfoot>
+  </table>
+
+  <?php do_action( 'woocommerce_order_details_after_order_table', $order ); ?>
+</section>
+
+<?php
+if ( $show_customer_details ) {
+  wc_get_template( 'order/order-details-customer.php', array( 'order' => $order ) );
+}

--- a/wp-content/themes/storefront-child/woocommerce/order/order-details.php
+++ b/wp-content/themes/storefront-child/woocommerce/order/order-details.php
@@ -38,7 +38,6 @@ if ( $show_downloads ) {
 <section class="woocommerce-order-details">
   <?php do_action( 'woocommerce_order_details_before_order_table', $order ); ?>
 
-  <h2 class="woocommerce-order-details__title"><?php _e( 'Order details', 'woocommerce' ); ?></h2>
   <table class="woocommerce-table woocommerce-table--order-details shop_table order_details">
     <thead>
       <tr>


### PR DESCRIPTION
~*work in progress. don't merge yet.*~

Documenting the steps to style an existing WooCommerce template:
1. `foreman start -f Procfile.dev` and Compass will watch sass file changes and compile CSS.
1. To override a [WooCommerce template](https://github.com/woocommerce/woocommerce/tree/release/3.5/templates/), locate the template under your `wp-content/plugins/woocommerce/templates/`, and copy over to corresponding folder in your theme, i.e. in our case, `wp-content/themes/storefront-child/woocommerce/`.
1. Change the indentation to 2 whitespaces.
1. Change the template as needed and style it by modifying sass files in `wp-content/themes/storefront-child/sass`.
1. A template might render other templates. Follow steps 2-4 until finished.

![order-details](https://user-images.githubusercontent.com/796573/48360966-692abe00-e66e-11e8-87b1-2d826f2b0643.png)

https://codex.wordpress.org/Plugin_API#Actions
https://codex.wordpress.org/Plugin_API#Filters
https://codex.wordpress.org/Plugin_API/Action_Reference
https://tommcfarlin.com/wordpress-page-lifecycle/

https://docs.woocommerce.com/wc-apidocs/hook-docs.html
https://github.com/woocommerce/woocommerce/blob/78015f726584f79d9a1a66edc1dbc7f1b63f57c2/includes/wc-template-functions.php#L2395

https://github.com/woocommerce/woocommerce/blob/d0491072e8a7d0a4535db0ec2bae4a6d43ff64fd/includes/wc-template-hooks.php#L251
https://github.com/woocommerce/woocommerce/blob/babfacd6bb41d8ae937abeb0383854e58603ff64/includes/wc-template-functions.php#L2380-L2396