### PR TITLE
Only redirect requests if it's not already HTTPS

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -124,6 +124,11 @@ define('AS3CF_SETTINGS', serialize(array(
 if ( !defined('ABSPATH') )
 	define('ABSPATH', dirname(__FILE__) . '/');
 
+// Only redirect requests if it's not already HTTPS. Note that this has to
+// come before `require_once(ABSPATH . 'wp-settings.php');`
+// https://stackoverflow.com/questions/27193575/wordpress-cloudfront-flexible-ssl-ends-up-in-redirect-loop-https/27193576#27193576
+if ($_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') $_SERVER['HTTPS'] = 'on';
+
 /** Sets up WordPress vars and included files. */
 require_once(ABSPATH . 'wp-settings.php');
 


### PR DESCRIPTION
After enabling SSL for production site, we started to notice 2 issues:

- "too many redirects" errors when accessing the https site:
Fixed by adding `if ($_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') $_SERVER['HTTPS'] = 'on';`.

- unusable admin (assets served from http instead of https):
Fixed by moving the above line to before `require_once(ABSPATH . 'wp-settings.php');` line.