### PR TITLE
Replace Sendgrid with Sendinblue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
     "wpackagist-plugin/perfect-woocommerce-brands": "^1.7.0",
     "wpackagist-plugin/regenerate-thumbnails": "3.1.3",
     "wpackagist-plugin/resize-image-after-upload": "1.8.6",
-    "wpackagist-plugin/sendgrid-email-delivery-simplified": "^1.11.4",
     "wpackagist-plugin/smart-slider-3": "^3.4.1",
     "wpackagist-plugin/woocommerce": "4.3.1",
     "wpackagist-plugin/woocommerce-gateway-stripe": "^4.2.2",
@@ -27,7 +26,7 @@
     "wpackagist-plugin/woocommerce-delivery-notes": "^4.6"
   },
   "scripts": {
-    "post-install-cmd": "wp plugin activate akismet sendgrid-email-delivery-simplified woocommerce insert-html-snippet perfect-woocommerce-brands woocommerce-gateway-stripe amazon-s3-and-cloudfront wp-user-avatar smart-slider-3 regenerate-thumbnails resize-image-after-upload filebird official-mailerlite-sign-up-forms woocommerce-delivery-notes; wp theme activate storefront-child",
+    "post-install-cmd": "wp plugin activate akismet woocommerce insert-html-snippet perfect-woocommerce-brands woocommerce-gateway-stripe amazon-s3-and-cloudfront wp-user-avatar smart-slider-3 regenerate-thumbnails resize-image-after-upload filebird official-mailerlite-sign-up-forms woocommerce-delivery-notes; wp theme activate storefront-child",
     "test": "phpunit -v tests"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,11 @@
     "wpackagist-plugin/woocommerce-gateway-stripe": "^4.2.2",
     "wpackagist-plugin/wp-user-avatar": "^2.2.5",
     "wpackagist-theme/storefront": "^2.3.5",
-    "wpackagist-plugin/woocommerce-delivery-notes": "^4.6"
+    "wpackagist-plugin/woocommerce-delivery-notes": "^4.6",
+    "wpackagist-plugin/mailin": "^3.1"
   },
   "scripts": {
-    "post-install-cmd": "wp plugin activate akismet woocommerce insert-html-snippet perfect-woocommerce-brands woocommerce-gateway-stripe amazon-s3-and-cloudfront wp-user-avatar smart-slider-3 regenerate-thumbnails resize-image-after-upload filebird official-mailerlite-sign-up-forms woocommerce-delivery-notes; wp theme activate storefront-child",
+    "post-install-cmd": "wp plugin activate akismet woocommerce insert-html-snippet perfect-woocommerce-brands woocommerce-gateway-stripe amazon-s3-and-cloudfront wp-user-avatar smart-slider-3 regenerate-thumbnails resize-image-after-upload filebird official-mailerlite-sign-up-forms woocommerce-delivery-notes mailin; wp theme activate storefront-child",
     "test": "phpunit -v tests"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8180fdd0b21ef196d4a0bdbc167deb27",
+    "content-hash": "8339336dfff30f76f7e8d538f98275d0",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -144,16 +144,16 @@
         },
         {
             "name": "composer/installers",
-            "version": "v1.10.0",
+            "version": "v1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/installers.git",
-                "reference": "1a0357fccad9d1cc1ea0c9a05b8847fbccccb78d"
+                "reference": "ae03311f45dfe194412081526be2e003960df74b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/installers/zipball/1a0357fccad9d1cc1ea0c9a05b8847fbccccb78d",
-                "reference": "1a0357fccad9d1cc1ea0c9a05b8847fbccccb78d",
+                "url": "https://api.github.com/repos/composer/installers/zipball/ae03311f45dfe194412081526be2e003960df74b",
+                "reference": "ae03311f45dfe194412081526be2e003960df74b",
                 "shasum": ""
             },
             "require": {
@@ -247,6 +247,7 @@
                 "majima",
                 "mako",
                 "mediawiki",
+                "miaoxing",
                 "modulework",
                 "modx",
                 "moodle",
@@ -264,13 +265,14 @@
                 "sydes",
                 "sylius",
                 "symfony",
+                "tastyigniter",
                 "typo3",
                 "wordpress",
                 "yawik",
                 "zend",
                 "zikula"
             ],
-            "time": "2021-01-14T11:07:16+00:00"
+            "time": "2021-04-28T06:42:17+00:00"
         },
         {
             "name": "composer/semver",
@@ -1687,7 +1689,9 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/akismet.4.1.6.zip"
+                "url": "https://downloads.wordpress.org/plugin/akismet.4.1.6.zip",
+                "reference": null,
+                "shasum": null
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -1705,7 +1709,9 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/all-in-one-wp-migration.7.25.zip"
+                "url": "https://downloads.wordpress.org/plugin/all-in-one-wp-migration.7.25.zip",
+                "reference": null,
+                "shasum": null
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -1723,7 +1729,9 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/amazon-s3-and-cloudfront.2.4.1.zip"
+                "url": "https://downloads.wordpress.org/plugin/amazon-s3-and-cloudfront.2.4.1.zip",
+                "reference": null,
+                "shasum": null
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -1741,7 +1749,9 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/filebird.zip?timestamp=1603794275"
+                "url": "https://downloads.wordpress.org/plugin/filebird.zip?timestamp=1603794275",
+                "reference": null,
+                "shasum": null
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -1759,7 +1769,9 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/insert-html-snippet.1.3.1.zip"
+                "url": "https://downloads.wordpress.org/plugin/insert-html-snippet.1.3.1.zip",
+                "reference": null,
+                "shasum": null
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -1777,7 +1789,9 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/official-mailerlite-sign-up-forms.1.4.7.zip"
+                "url": "https://downloads.wordpress.org/plugin/official-mailerlite-sign-up-forms.1.4.7.zip",
+                "reference": null,
+                "shasum": null
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -1795,7 +1809,9 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/perfect-woocommerce-brands.1.8.3.zip"
+                "url": "https://downloads.wordpress.org/plugin/perfect-woocommerce-brands.1.8.3.zip",
+                "reference": null,
+                "shasum": null
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -1813,7 +1829,9 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/regenerate-thumbnails.3.1.3.zip"
+                "url": "https://downloads.wordpress.org/plugin/regenerate-thumbnails.3.1.3.zip",
+                "reference": null,
+                "shasum": null
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -1831,31 +1849,15 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/resize-image-after-upload.1.8.6.zip"
+                "url": "https://downloads.wordpress.org/plugin/resize-image-after-upload.1.8.6.zip",
+                "reference": null,
+                "shasum": null
             },
             "require": {
                 "composer/installers": "~1.0"
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/resize-image-after-upload/"
-        },
-        {
-            "name": "wpackagist-plugin/sendgrid-email-delivery-simplified",
-            "version": "1.11.8",
-            "source": {
-                "type": "svn",
-                "url": "https://plugins.svn.wordpress.org/sendgrid-email-delivery-simplified/",
-                "reference": "tags/1.11.8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/sendgrid-email-delivery-simplified.1.11.8.zip"
-            },
-            "require": {
-                "composer/installers": "~1.0"
-            },
-            "type": "wordpress-plugin",
-            "homepage": "https://wordpress.org/plugins/sendgrid-email-delivery-simplified/"
         },
         {
             "name": "wpackagist-plugin/smart-slider-3",
@@ -1867,7 +1869,9 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/smart-slider-3.3.4.1.8.zip"
+                "url": "https://downloads.wordpress.org/plugin/smart-slider-3.3.4.1.8.zip",
+                "reference": null,
+                "shasum": null
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -1885,7 +1889,9 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/woocommerce.4.3.1.zip"
+                "url": "https://downloads.wordpress.org/plugin/woocommerce.4.3.1.zip",
+                "reference": null,
+                "shasum": null
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -1903,7 +1909,9 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/woocommerce-delivery-notes.4.6.2.zip"
+                "url": "https://downloads.wordpress.org/plugin/woocommerce-delivery-notes.4.6.2.zip",
+                "reference": null,
+                "shasum": null
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -1921,7 +1929,9 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/woocommerce-gateway-stripe.4.5.0.zip"
+                "url": "https://downloads.wordpress.org/plugin/woocommerce-gateway-stripe.4.5.0.zip",
+                "reference": null,
+                "shasum": null
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -1939,7 +1949,9 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/wp-user-avatar.2.2.7.zip"
+                "url": "https://downloads.wordpress.org/plugin/wp-user-avatar.2.2.7.zip",
+                "reference": null,
+                "shasum": null
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -1957,7 +1969,9 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/theme/storefront.2.5.8.zip"
+                "url": "https://downloads.wordpress.org/theme/storefront.2.5.8.zip",
+                "reference": null,
+                "shasum": null
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -3434,6 +3448,5 @@
         "ext-gd": "*",
         "php": "~7.4.0"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "platform-dev": []
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8339336dfff30f76f7e8d538f98275d0",
+    "content-hash": "0fa1c967945332fd4daf7914ba8815ef",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -1778,6 +1778,26 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/insert-html-snippet/"
+        },
+        {
+            "name": "wpackagist-plugin/mailin",
+            "version": "3.1.13",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/mailin/",
+                "reference": "tags/3.1.13"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/mailin.3.1.13.zip",
+                "reference": null,
+                "shasum": null
+            },
+            "require": {
+                "composer/installers": "~1.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/mailin/"
         },
         {
             "name": "wpackagist-plugin/official-mailerlite-sign-up-forms",


### PR DESCRIPTION
Sendgrid wordpress plugin is no longer maintained. Let's switch to Sendinblue.