### PR TITLE
Update WooCommerce to 5.7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "wpackagist-plugin/regenerate-thumbnails": "3.1.3",
     "wpackagist-plugin/resize-image-after-upload": "1.8.6",
     "wpackagist-plugin/smart-slider-3": "^3.4.1",
-    "wpackagist-plugin/woocommerce": "4.3.3",
+    "wpackagist-plugin/woocommerce": "5.7.0",
     "wpackagist-plugin/wp-user-avatar": "^2.2.5",
     "wpackagist-theme/storefront": "^2.3.5",
     "wpackagist-plugin/woocommerce-delivery-notes": "^4.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f61d73e105a2716a69eb52fff5e3b2ac",
+    "content-hash": "217f00d18adb7c2da4a5ade836129885",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -4625,15 +4625,15 @@
         },
         {
             "name": "wpackagist-plugin/woocommerce",
-            "version": "4.3.3",
+            "version": "5.7.0",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/woocommerce/",
-                "reference": "tags/4.3.3"
+                "reference": "tags/5.7.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/woocommerce.4.3.3.zip"
+                "url": "https://downloads.wordpress.org/plugin/woocommerce.5.7.0.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"


### PR DESCRIPTION
Facebook for WooCommerce will soon discontinue support for WooCommerce 4.3. We are also seeing some weirdness of the integration. Let's upgrade it to v5.7.0 which is the latest version that Facebook for WooCommerce tested.

![Screen Shot 2021-12-25 at 3 49 13 PM](https://user-images.githubusercontent.com/796573/147393404-b79ac04b-6908-4312-8a6d-254a4858ef7e.png)
